### PR TITLE
fix a bug when nothing detect

### DIFF
--- a/main.py
+++ b/main.py
@@ -104,8 +104,9 @@ class my_nanodet():
         classIds = np.argmax(mlvl_scores, axis=1)
         confidences = np.max(mlvl_scores, axis=1)  ####max_class_confidence
 
-        indices = cv2.dnn.NMSBoxes(bboxes_wh.tolist(), confidences.tolist(), self.prob_threshold, self.iou_threshold).flatten()
+        indices = cv2.dnn.NMSBoxes(bboxes_wh.tolist(), confidences.tolist(), self.prob_threshold, self.iou_threshold)
         if len(indices)>0:
+            indices=indices.flatten()
             mlvl_bboxes = mlvl_bboxes[indices]
             confidences = confidences[indices]
             classIds = classIds[indices]


### PR DESCRIPTION
When nothing detected, `cv2.dnn.NMSBoxes` would return an empty tuple which has no attribute 'flatten'. Thus it would cause an AttributeError.
```
Traceback (most recent call last):
  File "main.py", line 158, in <module>
    srcimg = net.detect(srcimg)
  File "main.py", line 133, in detect
    det_bboxes, det_conf, det_classid = self.post_process(outs)
  File "main.py", line 69, in post_process
    det_bboxes, det_conf, det_classid = self.get_bboxes_single(cls_scores, bbox_preds, 1, rescale=False)
  File "main.py", line 107, in get_bboxes_single
    indices = cv2.dnn.NMSBoxes(bboxes_wh.tolist(), confidences.tolist(), self.prob_threshold, self.iou_threshold).flatten()
AttributeError: 'tuple' object has no attribute 'flatten'
``` 

So `flatten()` should be called after the check of indices' emptiness.